### PR TITLE
Fixed release workflow

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,6 +1,7 @@
 .git/
 .github/
 .gitignore
+#!include:.gitignore
 *~
 *.back
 .*.swp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,13 @@ jobs:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v2
 
-      # https://github.com/google-github-actions/setup-gcloud
-      - uses: google-github-actions/setup-gcloud@master
+      # https://github.com/google-github-actions/auth
+      - uses: 'google-github-actions/auth@v0'
         with:
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+      # https://github.com/google-github-actions/setup-gcloud
+      - uses: 'google-github-actions/setup-gcloud@v0'
 
       - name: Check Cloud SDK version/components
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   dump:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 .*.swp
+
+# Ignore generated credentials from google-github-actions/auth
+# https://github.com/google-github-actions/auth#prerequisites
+# https://github.com/google-github-actions/auth/blob/main/docs/TROUBLESHOOTING.md#dirty-git-or-bundled-credentials
+gha-creds-*.json
+


### PR DESCRIPTION
- Updated Google Cloud SDK setup action
- Added workflow_dispatch
- Ignore `gha-creds-*.json` (service acocount JSON key file generated by google-github-actions/auth action)
- `${{ secrets.GCP_SA_EMAIL }}` has been removed, so removed `GCP_SA_EMAIL` from [Actions secrets](https://github.com/groovenauts/magellan-gcs-uploader/settings/secrets/actions).
